### PR TITLE
Changed: only show errors on azure cli

### DIFF
--- a/config/dotfiles/azure/config.ini
+++ b/config/dotfiles/azure/config.ini
@@ -10,7 +10,7 @@ name=AzureCloud
 collect_telemetry=false
 disable_confirm_prompt=false
 no_color=true
-only_show_errors=false
+only_show_errors=true
 output=json
 
 [defaults]


### PR DESCRIPTION
***What does this change do?***

- Changed: only show errors on azure cli

***Why is this change needed?***

- Avoid getting lots of warnings in terraform plan and apply commands