### PR TITLE
Removed: trigger CI on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: ci
 
 on: # yamllint disable-line rule:truthy
   pull_request:
-  push:
   schedule:
     - cron: "45 9 1-28/2 * *"
   workflow_dispatch:


### PR DESCRIPTION
***What does this change do?***

- Removed: trigger CI on push

***Why is this change needed?***

- Too many jobs being triggered