### PR TITLE
Changed: trigger ci on merged or push to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@
 name: ci
 
 on: # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: "45 9 1-28/2 * *"


### PR DESCRIPTION
***What does this change do?***

- Changed: trigger ci on merged or push to master

***Why is this change needed?***

- master latest build wanted