### PR TITLE
Fixed: Github runners running out of space

### DIFF
--- a/bin/main.sh
+++ b/bin/main.sh
@@ -50,6 +50,7 @@ function install() {
     exec_with_retries "${PROJECT_ROOT}/bin/install/go.sh" 0 2 "${GO_VERSION}"
     exec_with_retries "${PROJECT_ROOT}/bin/install/jq.sh" 0 2 "${JQ_VERSION}"
     exec_with_retries "${PROJECT_ROOT}/bin/install/rust.sh" 0 2 "${RUST_VERSION}"
+    sudo apt autoremove --purge -y
 
     # Phase 2
     exec_with_retries "${PROJECT_ROOT}/bin/install/alacritty.sh" 0 2 "${ALACRITTY_VERSION}"
@@ -84,6 +85,7 @@ function install() {
     exec_with_retries "${PROJECT_ROOT}/bin/install/tmuxinator.sh" 0 2 "${TMUXINATOR_VERSION}"
     exec_with_retries "${PROJECT_ROOT}/bin/install/vint.sh" 0 2 "${VINT_VERSION}"
     exec_with_retries "${PROJECT_ROOT}/bin/install/yamllint.sh" 0 2 "${YAMLLINT_VERSION}"
+    sudo apt autoremove --purge -y
 
     # Phase 3
     exec_with_retries "${PROJECT_ROOT}/bin/install/tmux_plugin_manager.sh" 0 2 "${TMUX_PLUGIN_MANAGER_VERSION}"


### PR DESCRIPTION
***What does this change do?***

- Github runners running out of space, try free up
some memory with apt autoremove command and see if it frees
up enough to allow full build. Not a long term solution though. Self
hosted runners are probably only long term solution

***Why is this change needed?***

- Failing build as is due to insufficient disk on github runner