### PR TITLE
Fixed: issue in setup_powerline function exiting

### DIFF
--- a/bin/configure/powerline.sh
+++ b/bin/configure/powerline.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
+# shellcheck disable=2009,2143
 set -eo pipefail
 
 function setup_powerline() {
     local powerline_path
-    powerline_path="$(python3 -m site --user-site)/powerline"
+    powerline_path="$(python3 -m site --user-site || true)/powerline"
 
     if [[ -d "${powerline_path}" ]]; then
-        "${HOME}/.local/bin/powerline-daemon" -q || true
+        if [[ -z "$(ps aux | grep "powerline-daemon" | awk NR==1 | grep -v grep)" ]]; then
+            "${HOME}/.local/bin/powerline-daemon" --quiet
+        else
+            "${HOME}/.local/bin/powerline-daemon" --replace --quiet
+        fi
         export POWERLINE_COMMAND_ARGS=""
         export POWERLINE_SHELL_CONTINUATION=1
         export POWERLINE_BASH_CONTINUATION=1


### PR DESCRIPTION
***What does this change do?***

- Fixed: issue in setup_powerline function exiting

***Why is this change needed?***

- Causes all terminals to crash on startup