### PR TITLE
Fixed: install vimrc config file if missing

### DIFF
--- a/bin/fallbacks.sh
+++ b/bin/fallbacks.sh
@@ -320,3 +320,24 @@ function maybe_install_flatpak_as_fallback() {
         echo "Flatpak version $(flatpak --version | cut -d ' ' -f2) already installed"
     fi
 }
+
+function maybe_configure_vimrc_as_fallback() {
+    if [[ ! -e "${HOME}/.vimrc" ]]; then
+        echo "Attempting to configure .vimrc from local files"
+        if [[ -e "${PROJECT_ROOT}/config/dotfiles/vim/vimrc" ]]; then
+            cp \
+                "${PROJECT_ROOT}/config/dotfiles/vim/vimrc" \
+                "${HOME}/.vimrc"
+        else
+            echo "Falling back to remote vimrc file ${GITHUB_URL}/config/dotfiles/vim/vimrc"
+            if curl -sIf -o /dev/null ${GITHUB_URL}/config/dotfiles/vim/vimrc; then
+                curl "${GITHUB_URL}/config/dotfiles/vim/vimrc" >"${HOME}/.vimrc"
+            else
+                echo "${GITHUB_URL}/config/dotfiles/vim/vimrc does not exist" >/dev/stderr
+                return 1
+            fi
+        fi
+    else
+        echo "${HOME}/.vimrc is already configured"
+    fi
+}

--- a/bin/install/vim.sh
+++ b/bin/install/vim.sh
@@ -143,6 +143,10 @@ function install_language_servers() {
         rm -rf "${HOME}/.config/coc/extensions/node_modules"
     fi
 
+    if [[ ! -e "${HOME}/.vimrc" ]]; then
+        maybe_configure_vimrc_as_fallback
+    fi
+
     NERDTREE_CLOSED=true vim +PlugClean +qall
     NERDTREE_CLOSED=true vim +PlugInstall +qall
 


### PR DESCRIPTION
***What does this change do?***

- Fixed: install vimrc config file if missing

***Why is this change needed?***

- Because the vimrc plugins will not be installed without having config
file