### PR TITLE
Added: adb to list of debian pkgs for installation

### DIFF
--- a/bin/install/debian_pkgs.sh
+++ b/bin/install/debian_pkgs.sh
@@ -25,6 +25,7 @@ fi
 
 declare -A DEBIAN_PKGS
 DEBIAN_PKGS=(
+    ["adb"]="*"
     ["bash-completion"]="*"
     ["dialog"]="*"
     ["exuberant-ctags"]="*"


### PR DESCRIPTION
***What does this change do?***

Added: adb to list of debian pkgs for installation

***Why is this change needed?***

- Install adb for access to android phones