### PR TITLE
Fixed: Some vars not source when fallbacks false

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,14 @@
 # shellcheck disable=SC2034,SC2148
 
+# Miscellaneous
+XKBLAYOUT=us
+BACKSPACE=guess
+XKBMODEL=pc105
+LANG=en_US.UTF-8
+LANGUAGE=en_US.UTF-8
+LC_ALL=en_US.UTF-8
+TZ=Europe/Zurich
+
 # Rust Tools
 RUST_VERSION=1.59.0
 BAT_VERSION=0.19.0

--- a/.env
+++ b/.env
@@ -1,14 +1,5 @@
 # shellcheck disable=SC2034,SC2148
 
-# Miscellaneous
-XKBLAYOUT=us
-BACKSPACE=guess
-XKBMODEL=pc105
-TZ=Europe/Zurich
-LANG=en_US.UTF-8
-LANGUAGE=en_US.UTF-8
-LC_ALL=en_US.UTF-8
-
 # Rust Tools
 RUST_VERSION=1.59.0
 BAT_VERSION=0.19.0

--- a/bin/main.sh
+++ b/bin/main.sh
@@ -57,44 +57,44 @@ function install() {
 
     # Phase 1
     exec_with_retries "${PROJECT_ROOT}/bin/install/debian_pkgs.sh" 0 2
-    exec_with_retries "${PROJECT_ROOT}/bin/install/go.sh" 0 2 "${GO_VERSION}"
-    exec_with_retries "${PROJECT_ROOT}/bin/install/jq.sh" 0 2 "${JQ_VERSION}"
-    exec_with_retries "${PROJECT_ROOT}/bin/install/rust.sh" 0 2 "${RUST_VERSION}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/go.sh" 0 2 "${GO_VERSION:-}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/jq.sh" 0 2 "${JQ_VERSION:-}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/rust.sh" 0 2 "${RUST_VERSION:-}"
 
     # Phase 2
-    exec_with_retries "${PROJECT_ROOT}/bin/install/alacritty.sh" 0 2 "${ALACRITTY_VERSION}"
-    exec_with_retries "${PROJECT_ROOT}/bin/install/argos_translate.sh" 0 2 "${ARGOS_TRANSLATE_GUI_VERSION}"
-    exec_with_retries "${PROJECT_ROOT}/bin/install/ansible.sh" 0 2 "${ANSIBLE_VERSION}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/alacritty.sh" 0 2 "${ALACRITTY_VERSION:-}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/argos_translate.sh" 0 2 "${ARGOS_TRANSLATE_GUI_VERSION:-}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/ansible.sh" 0 2 "${ANSIBLE_VERSION:-}"
     exec_with_retries "${PROJECT_ROOT}/bin/install/ansible_modules.sh" 0 2
-    exec_with_retries "${PROJECT_ROOT}/bin/install/asdf.sh" 0 2 "${ASDF_VERSION}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/asdf.sh" 0 2 "${ASDF_VERSION:-}"
     exec_with_retries "${PROJECT_ROOT}/bin/install/asdf_plugins.sh" 0 2
-    exec_with_retries "${PROJECT_ROOT}/bin/install/azure_cli.sh" 0 2 "${AZURE_CLI_VERSION}"
-    exec_with_retries "${PROJECT_ROOT}/bin/install/black.sh" 0 2 "${BLACK_VERSION}"
-    exec_with_retries "${PROJECT_ROOT}/bin/install/bpytop.sh" 0 2 "${BPYTOP_VERSION}"
-    exec_with_retries "${PROJECT_ROOT}/bin/install/diagrams.sh" 0 2 "${DIAGRAMS_VERSION}"
-    exec_with_retries "${PROJECT_ROOT}/bin/install/docker.sh" 0 2 "${DOCKER_VERSION}"
-    exec_with_retries "${PROJECT_ROOT}/bin/install/docker_compose.sh" 0 2 "${DOCKER_COMPOSE_VERSION}"
-    exec_with_retries "${PROJECT_ROOT}/bin/install/dotnet_core.sh" 0 2 "${DOTNET_CORE_SDK_VERSION}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/azure_cli.sh" 0 2 "${AZURE_CLI_VERSION:-}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/black.sh" 0 2 "${BLACK_VERSION:-}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/bpytop.sh" 0 2 "${BPYTOP_VERSION:-}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/diagrams.sh" 0 2 "${DIAGRAMS_VERSION:-}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/docker.sh" 0 2 "${DOCKER_VERSION:-}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/docker_compose.sh" 0 2 "${DOCKER_COMPOSE_VERSION:-}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/dotnet_core.sh" 0 2 "${DOTNET_CORE_SDK_VERSION:-}"
     if [[ "$(is_docker)" != "true" ]] && [[ "$(headless_only)" != "true" ]]; then
-        "${PROJECT_ROOT}/bin/install/flatpak.sh" "${FLATPAK_VERSION}" "${FREEDESKTOP_VERSION}"
+        "${PROJECT_ROOT}/bin/install/flatpak.sh" "${FLATPAK_VERSION:-}" "${FREEDESKTOP_VERSION:-}"
         exec_with_retries "${PROJECT_ROOT}/bin/install/flatpak_pkgs.sh" 0 2
     fi
-    exec_with_retries "${PROJECT_ROOT}/bin/install/gogh.sh" 0 2 "${GOGH_VERSION}"
-    exec_with_retries "${PROJECT_ROOT}/bin/install/jmespath.sh" 0 2 "${JMESPATH_VERSION}"
-    exec_with_retries "${PROJECT_ROOT}/bin/install/krew.sh" 0 2 "${KREW_VERSION}"
-    "${PROJECT_ROOT}/bin/install/pgcli.sh" "${PGCLI_VERSION}" "${POSTGRESQL_CLIENT_VERSION}"
-    exec_with_retries "${PROJECT_ROOT}/bin/install/nerd_fonts.sh" 0 2 "${NERDFONTS_VERSION}"
-    exec_with_retries "${PROJECT_ROOT}/bin/install/pencil.sh" 0 2 "${PENCIL_VERSION}"
-    exec_with_retries "${PROJECT_ROOT}/bin/install/pipx.sh" 0 2 "${PIPX_VERSION}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/gogh.sh" 0 2 "${GOGH_VERSION:-}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/jmespath.sh" 0 2 "${JMESPATH_VERSION:-}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/krew.sh" 0 2 "${KREW_VERSION:-}"
+    "${PROJECT_ROOT}/bin/install/pgcli.sh" "${PGCLI_VERSION:-}" "${POSTGRESQL_CLIENT_VERSION:-}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/nerd_fonts.sh" 0 2 "${NERDFONTS_VERSION:-}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/pencil.sh" 0 2 "${PENCIL_VERSION:-}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/pipx.sh" 0 2 "${PIPX_VERSION:-}"
     exec_with_retries "${PROJECT_ROOT}/bin/install/rust_pkgs.sh" 0 2
-    exec_with_retries "${PROJECT_ROOT}/bin/install/shellcheck.sh" 0 2 "${SHELLCHECK_VERSION}"
-    exec_with_retries "${PROJECT_ROOT}/bin/install/shfmt.sh" 0 2 "${SHFMT_VERSION}"
-    exec_with_retries "${PROJECT_ROOT}/bin/install/tmuxinator.sh" 0 2 "${TMUXINATOR_VERSION}"
-    exec_with_retries "${PROJECT_ROOT}/bin/install/vint.sh" 0 2 "${VINT_VERSION}"
-    exec_with_retries "${PROJECT_ROOT}/bin/install/yamllint.sh" 0 2 "${YAMLLINT_VERSION}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/shellcheck.sh" 0 2 "${SHELLCHECK_VERSION:-}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/shfmt.sh" 0 2 "${SHFMT_VERSION:-}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/tmuxinator.sh" 0 2 "${TMUXINATOR_VERSION:-}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/vint.sh" 0 2 "${VINT_VERSION:-}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/yamllint.sh" 0 2 "${YAMLLINT_VERSION:-}"
 
     # Phase 3
-    exec_with_retries "${PROJECT_ROOT}/bin/install/tmux_plugin_manager.sh" 0 2 "${TMUX_PLUGIN_MANAGER_VERSION}"
+    exec_with_retries "${PROJECT_ROOT}/bin/install/tmux_plugin_manager.sh" 0 2 "${TMUX_PLUGIN_MANAGER_VERSION:-}"
     "${PROJECT_ROOT}/bin/install/vim.sh" \
         "${VIM_GTK3_VERSION:-latest}" \
         "${VIM_PLUG_VERSION:-0.11.0}" \

--- a/bin/preinstall.sh
+++ b/bin/preinstall.sh
@@ -42,13 +42,13 @@ function preinstall() {
     fi
 
     # Setting vars common regardless of fallbacks
-    if [[ -z "${XKBLAYOUT}" ]]; then export XKBLAYOUT=us; fi
-    if [[ -z "${BACKSPACE}" ]]; then export BACKSPACE=guess; fi
-    if [[ -z "${XKBMODEL}" ]]; then export XKBMODEL=pc105; fi
-    if [[ -z "${TZ}" ]]; then export TZ=Europe/Zurich; fi
-    if [[ -z "${LANG}" ]]; then export LANG=en_US.UTF-8; fi
-    if [[ -z "${LANGUAGE}" ]]; then export LANGUAGE=en_US.UTF-8; fi
-    if [[ -z "${LC_ALL}" ]]; then export LC_ALL=en_US.UTF-8; fi
+    if [[ -z "${XKBLAYOUT:-}" ]]; then export XKBLAYOUT=us; fi
+    if [[ -z "${BACKSPACE:-}" ]]; then export BACKSPACE=guess; fi
+    if [[ -z "${XKBMODEL:-}" ]]; then export XKBMODEL=pc105; fi
+    if [[ -z "${TZ:-}" ]]; then export TZ=Europe/Zurich; fi
+    if [[ -z "${LANG:-}" ]]; then export LANG=en_US.UTF-8; fi
+    if [[ -z "${LANGUAGE:-}" ]]; then export LANGUAGE=en_US.UTF-8; fi
+    if [[ -z "${LC_ALL:-}" ]]; then export LC_ALL=en_US.UTF-8; fi
 
     source "${PROJECT_ROOT}/bin/configure/misc.sh"
     setup_locales

--- a/bin/preinstall.sh
+++ b/bin/preinstall.sh
@@ -41,6 +41,15 @@ function preinstall() {
         echo "Default fallback versions will be adpoted"
     fi
 
+    # Setting vars common regardless of fallbacks
+    if [[ -z "${XKBLAYOUT}" ]]; then export XKBLAYOUT=us; fi
+    if [[ -z "${BACKSPACE}" ]]; then export BACKSPACE=guess; fi
+    if [[ -z "${XKBMODEL}" ]]; then export XKBMODEL=pc105; fi
+    if [[ -z "${TZ}" ]]; then export TZ=Europe/Zurich; fi
+    if [[ -z "${LANG}" ]]; then export LANG=en_US.UTF-8; fi
+    if [[ -z "${LANGUAGE}" ]]; then export LANGUAGE=en_US.UTF-8; fi
+    if [[ -z "${LC_ALL}" ]]; then export LC_ALL=en_US.UTF-8; fi
+
     source "${PROJECT_ROOT}/bin/configure/misc.sh"
     setup_locales
     setup_timezone

--- a/bin/preinstall.sh
+++ b/bin/preinstall.sh
@@ -45,10 +45,40 @@ function preinstall() {
     if [[ -z "${XKBLAYOUT:-}" ]]; then export XKBLAYOUT=us; fi
     if [[ -z "${BACKSPACE:-}" ]]; then export BACKSPACE=guess; fi
     if [[ -z "${XKBMODEL:-}" ]]; then export XKBMODEL=pc105; fi
-    if [[ -z "${TZ:-}" ]]; then export TZ=Europe/Zurich; fi
+    if [[ -z "${TZ:-}" ]]; then export TZ=Etc/UTC; fi
     if [[ -z "${LANG:-}" ]]; then export LANG=en_US.UTF-8; fi
     if [[ -z "${LANGUAGE:-}" ]]; then export LANGUAGE=en_US.UTF-8; fi
     if [[ -z "${LC_ALL:-}" ]]; then export LC_ALL=en_US.UTF-8; fi
+
+    # Override 'C.UTF-8' due to error
+    # Error: 'C.UTF-8' is not a supported language or locale
+    if [[ "${LANG}" == "C.UTF-8" ]]; then
+        if [[ "${SOURCE_ENV_FILE}" == "true" ]]; then
+            echo "LANG set to 'C.UTF-8'" >&2
+            echo "This may not work" >&2
+            echo "The LANG can be changed in the .env file" >&2
+        else
+            echo "Overriding 'C.UTF-8' due to error" >&2
+            echo "Error: 'C.UTF-8' is not a supported language or locale" >&2
+            echo "Setting LANG to en_US.UTF-8 instead." >&2
+            echo "Alternatively, set LANG as required in the environment" >&2
+            export LANG=en_US.UTF-8
+        fi
+    fi
+    sleep 5s
+
+    echo """
+Variables set as follows:
+XKBLAYOUT: ${XKBLAYOUT}
+BACKSPACE: ${BACKSPACE}
+XKBMODEL: ${XKBMODEL}
+TZ: ${TZ}
+LANG: ${LANG}
+LANGUAGE: ${LANGUAGE}
+LC_ALL: ${LC_ALL}
+"""
+
+    sleep 5s
 
     source "${PROJECT_ROOT}/bin/configure/misc.sh"
     setup_locales


### PR DESCRIPTION
***What does this change do?***

- Fixed: Some vars not source when fallbacks false. Some
variables were not being sourced as expected in `.env` when
not using fallbacks. Hence moved variables out of `.env`

***Why is this change needed?***

- To ensure variables that are needed are set as required.
A build failure otherwise due to missing LANG