### PR TITLE
Fixed: use dowloadable asdf copy of websocat

### DIFF
--- a/config/dotfiles/asdf/tool-versions
+++ b/config/dotfiles/asdf/tool-versions
@@ -112,7 +112,7 @@ trdsql 0.9.1
 trivy 0.24.1
 vault 1.9.3
 velero v1.8.0
-websocat 1.10.0
+websocat 1.8.0
 yarn 1.22.17
 yor 0.1.139
 yq 4.25.3


### PR DESCRIPTION
***What does this change do?***

- Fixed:  latest use dowloadable asdf copy of websocat

***Why is this change needed?***

- asdf websocat plugin does not yet support the newer copies of websocat because the github download url for releases changed