### PR TITLE
Fixed: dotnetcore sdk version for fallback

### DIFF
--- a/bin/install/dotnet_core.sh
+++ b/bin/install/dotnet_core.sh
@@ -3,7 +3,7 @@ set -eu
 set -o pipefail
 set -o errtrace
 
-DOTNET_CORE_SDK_VERSION_FALLBACK=6.0
+DOTNET_CORE_SDK_VERSION_FALLBACK=6
 
 # ******* Importing utils.sh as a source of common shell functions *******
 GITHUB_URL=https://raw.githubusercontent.com/stephenmoloney/localbox/master


### PR DESCRIPTION
***What does this change do?***

- fixes issue with dotnet sdk version

***Why is this change needed?***

- needed to install dotnet sdk 6 with fallback