### PR TITLE
Fixed: broken link for pencil installation

### DIFF
--- a/bin/install/pencil.sh
+++ b/bin/install/pencil.sh
@@ -39,7 +39,7 @@ function install_pencil() {
 
     pushd "$(mktemp -d)" || exit
     wget \
-        "https://pencil.evolus.vn/dl/V${version}.ga/pencil_${version}.ga_amd64.deb" \
+        "https://pencil.evolus.vn/dl/V${version}.ga/Pencil_${version}.ga_amd64.deb" \
         -O "pencil_${version}.ga_amd64.deb"
 
     sudo dpkg --install "pencil_${version}.ga_amd64.deb"


### PR DESCRIPTION
***What does this change do?***

- Fixed: broken link for pencil installation after upgrade

***Why is this change needed?***

- Fix installation of pencil