### PR TITLE
 Added: gke-gcloud-auth-plugin for GKE clusters 

### DIFF
--- a/bin/configure/asdf_plugins.sh
+++ b/bin/configure/asdf_plugins.sh
@@ -61,6 +61,7 @@ function setup_gcloud() {
             source "${HOME}/.asdf/installs/gcloud/${gcloud_version}/path.bash.inc"
         fi
     fi
+    export USE_GKE_GCLOUD_AUTH_PLUGIN=True
 }
 
 function setup_starship() {

--- a/bin/install/asdf_plugins.sh
+++ b/bin/install/asdf_plugins.sh
@@ -159,9 +159,21 @@ function install_asdf_plugins() {
     done
 }
 
+function install_gcloud_components() {
+    local gcloud_components
+
+    mapfile -t gcloud_components <"${PROJECT_ROOT}/config/dotfiles/gcloud/default-cloud-sdk-components"
+
+    for component in "${gcloud_components[@]}"; do
+        gcloud components install "${component}"
+    done
+}
+
 function main() {
     source "${HOME}/.asdf/asdf.sh"
     install_asdf_plugins
+    install_gcloud_components
+    gcloud components update
 }
 
 # shellcheck disable=SC2086

--- a/config/dotfiles/asdf/tool-versions
+++ b/config/dotfiles/asdf/tool-versions
@@ -33,7 +33,7 @@ poetry 1.4.2 1.2.1
 protoc 3.20.3 3.20.2
 rclone 1.62.2 1.59.2
 rebar 3.20.0 3.18.0
-ruby 3.2.2 3.0.1
+ruby 3.2.0 3.0.1
 scaleway-cli 2.14.0 2.4.0
 shellspec 0.28.1
 skaffold 2.4.1 1.39.2

--- a/config/dotfiles/gcloud/default-cloud-sdk-components
+++ b/config/dotfiles/gcloud/default-cloud-sdk-components
@@ -3,6 +3,7 @@ beta
 cloud-build-local
 config-connector
 docker-credential-gcr
+gke-gcloud-auth-plugin
 kpt
 kubectl-oidc
 nomos


### PR DESCRIPTION
***What does this change do?***

- Installs the gke-gcloud-auth-plugin in order to
authenticate to GKE clusters. It's a kubectl plugin.

***Why is this change needed?***

- Allow connections to GKE clusters