### PR TITLE
Removed: uneccessary historical deps adsf

### DIFF
--- a/config/dotfiles/asdf/tool-versions
+++ b/config/dotfiles/asdf/tool-versions
@@ -1,53 +1,53 @@
-argo 3.5.2 3.4.11 3.4.7 3.3.9
-argocd 2.9.3 2.9.2 2.8.4 2.7.2 2.4.12
-argo-rollouts 1.6.2 1.6.0 1.5.0 1.2.2
-bats 1.10.0 1.9.0 1.8.0
-bitwarden 2023.10.0 2023.9.0 2023.5.0
-boundary 0.14.2 0.13.1 0.12.2 0.10.5
-cfssl 1.6.4 1.6.2
-checkov 3.1.20 3.1.18 2.4.48 2.3.239 2.1.210
-conftest 0.47.0 0.46.0 0.34.0
+argo 3.5.2
+argocd 2.9.3
+argo-rollouts 1.6.2
+bats 1.10.0
+bitwarden 2023.10.0
+boundary 0.14.2
+cfssl 1.6.4
+checkov 3.1.20
+conftest 0.47.0
 container-diff 0.17.0
 cue 0.6.0
-dyff 1.6.0 1.5.8 1.5.7
-dotenv-linter 3.3.0 3.2.0
-editorconfig-checker 2.7.2 2.7.1 2.7.0 2.6.0
-elixir 1.15.7 1.15.6 1.14.4 1.14.0 1.13.4 1.12.3 1.13.3 1.11.4
-erlang 26.1.2 26.0.2 25.3.2 24.2.2 25.0.4
-gcloud 455.0.0 447.0.0 430.0.0 374.0.0 402.0.0
-gitui 0.24.3 0.22.1 0.20.1 0.21.0
-golangci-lint 1.55.2 1.54.2 1.52.2 1.49.0
-groovy 4.0.16 4.0.15 4.0.12
-haskell 9.8.1 9.6.1 9.4.2
-helm 3.13.2 3.12.3 3.12.0 3.9.4
-helm-cr 1.6.1 1.6.0 1.5.0 1.4.0
-helm-ct 3.10.1 3.9.0 3.8.0 3.7.0
-helmfile 0.159.0 0.157.0 0.153.1 0.144.0
+dyff 1.6.0
+dotenv-linter 3.3.0
+editorconfig-checker 2.7.2
+elixir 1.15.7
+erlang 26.1.2
+gcloud 455.0.0
+gitui 0.24.3
+golangci-lint 1.55.2
+groovy 4.0.16
+haskell 9.8.1
+helm 3.13.2
+helm-cr 1.6.1
+helm-ct 3.10.1
+helmfile 0.159.0
 hey 0.1.4
-imgpkg 0.39.0 0.38.0 0.36.2
-istioctl 1.20.0 1.19.0 1.17.2 1.15.0
+imgpkg 0.39.0
+istioctl 1.20.0
 java adoptopenjdk-17.0.2+8 adoptopenjdk-18.0.2+101
-kbld 0.38.1 0.38.0 0.37.1
-kubectl 1.28.4 1.28.2 1.27.1 1.25.1 1.24.5 1.23.4 1.22.7 1.21.2 1.20.8
-kustomize 5.2.1 5.1.1 5.0.3 4.5.7
-lua 5.4.6 5.4.4 5.4.3
-nodejs 21.3.0 21.2.0 20.7.0 20.1.0 18.9.0 17.6.0 14.17.1
-packer 1.9.4 1.8.7 1.8.3
-poetry 1.7.1 1.6.1 1.4.2 1.2.1
-protoc 3.20.3 3.20.2
-rclone 1.65.0 1.64.0 1.62.2 1.59.2
-rebar 3.22.1 3.20.0 3.18.0
-ruby 3.2.2 3.2.0 3.0.1
-scaleway-cli 2.25.0 2.24.0 2.21.0 2.14.0 2.4.0
+kbld 0.38.1
+kubectl 1.28.4
+kustomize 5.2.1
+lua 5.4.6
+nodejs 21.3.0
+packer 1.9.4
+poetry 1.7.1
+protoc 3.20.3
+rclone 1.65.0
+rebar 3.22.1
+ruby 3.2.2
+scaleway-cli 2.25.0
 shellspec 0.28.1
-skaffold 2.9.0 2.7.1 2.4.1 1.39.2
-sops 3.8.1 3.7.3
-starship 1.16.0 1.14.2 1.10.3
-terraform 1.5.4 1.4.6 1.2.9 1.1.6 0.15.5 0.14.8 0.13.6 0.12.30
-tflint 0.49.0 0.46.1 0.40.0
-timoni 0.17.0 0.13.1
-vault 1.15.3 1.15.2 1.14.3 1.13.2 1.11.3
-websocat 1.12.0 1.11.0 1.10.0
+skaffold 2.9.0
+sops 3.8.1
+starship 1.16.0
+terraform 1.5.4
+tflint 0.49.0
+timoni 0.17.0
+vault 1.15.3
+websocat 1.12.0
 yarn 1.22.19
-ytt 0.46.2 0.45.1
-yq 4.40.4 4.40.3 4.35.1 4.33.3 4.27.5
+ytt 0.46.2
+yq 4.40.4


### PR DESCRIPTION
***What does this change do?***

- excess asdf toolversions deps

***Why is this change needed?***

- Only latest versions needed for now